### PR TITLE
Fixed rego rules of IAM and SQS

### DIFF
--- a/aws/iac/iam.rego
+++ b/aws/iac/iam.rego
@@ -21,7 +21,6 @@ aws_issue["iam_wildcard_resource"] {
 }
 
 iam_wildcard_resource {
-    lower(input.Resources[i].Type) == "aws::iam::managedpolicy"
     not aws_issue["iam_wildcard_resource"]
 }
 

--- a/aws/iac/sqs.rego
+++ b/aws/iac/sqs.rego
@@ -50,38 +50,25 @@ sqs_deadletter_metadata := {
 
 default sqs_encrypt_key = null
 
-aws_attribute_absence["sqs_encrypt_key"] {
-    resource := input.Resources[i]
-    lower(resource.Type) == "aws::sqs::queue"
-    not resource.Properties.KmsMasterKeyId
-}
 
 aws_issue["sqs_encrypt_key"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::sqs::queue"
+    resource.Properties.KmsMasterKeyId
     contains(lower(resource.Properties.KmsMasterKeyId), "alias/aws/sqs")
 }
 
 sqs_encrypt_key {
     lower(input.Resources[i].Type) == "aws::sqs::queue"
     not aws_issue["sqs_encrypt_key"]
-    not aws_attribute_absence["sqs_encrypt_key"]
 }
 
 sqs_encrypt_key = false {
     aws_issue["sqs_encrypt_key"]
-}
-
-sqs_encrypt_key = false {
-    aws_attribute_absence["sqs_encrypt_key"]
 }
 
 sqs_encrypt_key_err = "AWS SQS queue encryption using default KMS key instead of CMK" {
     aws_issue["sqs_encrypt_key"]
-}
-
-sqs_encrypt_key_miss_err = "SQS Queue attribute KmsMasterKeyId missing in the resource" {
-    aws_attribute_absence["sqs_encrypt_key"]
 }
 
 sqs_encrypt_key_metadata := {


### PR DESCRIPTION
- IAM
        Fixed rule is only checking for managedpolicy and policy get excluded. if both get present in single file then it is get ignored
- SQS
        Fixed rule if kmsmasterid should be available for checking the content. if kmsmasterid is not present then it is validating by other rule.
