### PR TITLE
Fixed cloudfront and security_group rules

### DIFF
--- a/aws/iac/cloudfront.rego
+++ b/aws/iac/cloudfront.rego
@@ -324,26 +324,33 @@ default cf_default_ssl = null
 aws_issue["cf_default_ssl"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::cloudfront::distribution"
-    resource.Properties.DistributionConfig.viewerCertificate.CloudFrontDefaultCertificate
+    lower(resource.Properties.DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate) == "true"
 }
 
-aws_issue["cf_default_ssl"] {
+aws_bool_issue["cf_default_ssl"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::cloudfront::distribution"
-    resource.Properties.DistributionConfig.viewerCertificate.CloudFrontDefaultCertificate == true
+    resource.Properties.DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate == true
 }
 
 cf_default_ssl {
     lower(input.Resources[i].Type) == "aws::cloudfront::distribution"
     not aws_issue["cf_default_ssl"]
+    not aws_bool_issue["cf_default_ssl"]
 }
 
 cf_default_ssl = false {
     aws_issue["cf_default_ssl"]
 }
 
+cf_default_ssl = false {
+    aws_bool_issue["cf_default_ssl"]
+}
+
 cf_default_ssl_err = "AWS CloudFront web distribution with default SSL certificate (deprecated)" {
     aws_issue["cf_default_ssl"]
+} else = "AWS CloudFront web distribution with default SSL certificate (deprecated)" {
+    aws_bool_issue["cf_default_ssl"]
 }
 
 cf_default_ssl_metadata := {

--- a/aws/iac/elasticsearch.rego
+++ b/aws/iac/elasticsearch.rego
@@ -466,7 +466,7 @@ aws_issue["esearch_encrypt_kms"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::elasticsearch::domain"
     lower(resource.Properties.EncryptionAtRestOptions.Enabled) == "true"
-    lower(resource.Properties.EncryptionAtRestOptions.KmsKeyId) == ""
+    count(resource.Properties.EncryptionAtRestOptions.KmsKeyId) == 0
 }
 
 aws_bool_issue["esearch_encrypt_kms"] {
@@ -480,7 +480,7 @@ aws_bool_issue["esearch_encrypt_kms"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::elasticsearch::domain"
     resource.Properties.EncryptionAtRestOptions.Enabled
-    lower(resource.Properties.EncryptionAtRestOptions.KmsKeyId) == ""
+    count(resource.Properties.EncryptionAtRestOptions.KmsKeyId) == 0
 }
 
 

--- a/aws/iac/msk.rego
+++ b/aws/iac/msk.rego
@@ -56,12 +56,6 @@ aws_issue["msk_encryption_at_rest_cmk"] {
     count(resource.Properties.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId) == 0
 }
 
-aws_issue["msk_encryption_at_rest_cmk"] {
-    resource := input.Resources[i]
-    lower(resource.Type) == "aws::msk::cluster"
-    resource.Properties.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId == null
-}
-
 msk_encryption_at_rest_cmk {
     lower(input.Resources[i].Type) == "aws::msk::cluster"
     not aws_issue["msk_encryption_at_rest_cmk"]

--- a/aws/iac/rds.rego
+++ b/aws/iac/rds.rego
@@ -115,6 +115,12 @@ aws_issue["rds_encrypt_key"] {
     not resource.Properties.KmsKeyId
 }
 
+aws_issue["rds_encrypt_key"] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::rds::dbinstance"
+    count(resource.Properties.KmsKeyId) == 0
+}
+
 rds_encrypt_key {
     lower(input.Resources[i].Type) == "aws::rds::dbinstance"
     not aws_issue["rds_encrypt_key"]

--- a/aws/iac/securitygroup.rego
+++ b/aws/iac/securitygroup.rego
@@ -46,16 +46,16 @@ aws_issue["all"] {
 aws_issue["proto_all"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::ec2::securitygroup"
-    ingress := resource.Properties.SecurityGroupIngress[_]
-    ingress.IpProtocol == "-1"
+    lower(resource.Properties.GroupName) == "default"
+    ingress := resource.Properties.SecurityGroupEgress[_]
     ingress.CidrIp == "0.0.0.0/0"
 }
 
 aws_issue["proto_all"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::ec2::securitygroup"
-    ingress := resource.Properties.SecurityGroupIngress[_]
-    ingress.IpProtocol == "-1"
+    lower(resource.Properties.GroupName) == "default"
+    ingress := resource.Properties.SecurityGroupEgress[_]
     ingress.CidrIpv6 == "::/0"
 }
 

--- a/aws/terraform/rds.rego
+++ b/aws/terraform/rds.rego
@@ -116,6 +116,12 @@ aws_issue["rds_encrypt_key"] {
     not resource.properties.kms_key_id
 }
 
+aws_issue["rds_encrypt_key"] {
+    resource := input.resources[i]
+    lower(resource.type) == "aws_db_instance"
+    count(resource.properties.kms_key_id) == 0
+}
+
 rds_encrypt_key {
     lower(input.resources[i].type) == "aws_db_instance"
     not aws_issue["rds_encrypt_key"]


### PR DESCRIPTION
- Added bool value validation for cloudfront distribution (PR-AWS-0022-CFR)
- Fixed Default Security Group does not restrict all traffic not covering egress rule violation (PR-AWS-0035-CFR)