### PR TITLE
extend test scope of 0045 and fixed 0035 rule

### DIFF
--- a/aws/iac/s3.rego
+++ b/aws/iac/s3.rego
@@ -94,6 +94,15 @@ aws_issue["s3_acl_delete"] {
     stat := resource.Properties.PolicyDocument.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:delete")
+}
+
+aws_issue["s3_acl_delete"] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
     startswith(lower(stat.Action[_]),"s3:delete")
 }
 
@@ -158,6 +167,15 @@ aws_issue["s3_acl_get"] {
     stat := resource.Properties.PolicyDocument.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:get")
+}
+
+aws_issue["s3_acl_get"] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
     startswith(lower(stat.Action[_]),"s3:get")
 }
 
@@ -214,6 +232,16 @@ aws_issue["s3_acl_list"] {
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
     lower(stat.Action[_]) == "s3:*"
+}
+
+aws_issue["s3_acl_list"] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:list")
+
 }
 
 aws_issue["s3_acl_list"] {
@@ -287,8 +315,17 @@ aws_issue["s3_acl_put"] {
     stat := resource.Properties.PolicyDocument.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
-    startswith(lower(stat.Action[_]),"s3:put")
+    startswith(lower(stat.Action),"s3:put")
 
+}
+
+aws_issue["s3_acl_put"] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[_]),"s3:put")
 }
 
 s3_acl_put {

--- a/aws/terraform/cloudfront.rego
+++ b/aws/terraform/cloudfront.rego
@@ -83,9 +83,8 @@ default cf_ssl_protocol = null
 aws_attribute_absence["cf_ssl_protocol"] {
     resource := input.resources[_]
     lower(resource.type) == "aws_cloudfront_distribution"
-    origin := resource.properties.origin[_]
-    custom_origin_config := origin.custom_origin_config[_]
-    not custom_origin_config.origin_ssl_protocols
+    viewer_certificate := resource.properties.viewer_certificate[_]
+    lower(viewer_certificate.minimum_protocol_version) == "sslv3"
 }
 
 aws_issue["cf_ssl_protocol"] {

--- a/aws/terraform/ec2.rego
+++ b/aws/terraform/ec2.rego
@@ -118,17 +118,29 @@ default ec2_public_ip = null
 aws_issue["ec2_public_ip"] {
     resource := input.resources[i]
     lower(resource.type) == "aws_instance"
-    network_interface := resource.properties.network_interface[_]
-    lower(network_interface.associate_public_ip_address) == "true"
+    lower(resource.properties.associate_public_ip_address) == "true"
+    lower(resource.properties.security_groups[_]) == "default"
+}
+
+aws_issue["ec2_public_ip"] {
+    resource := input.resources[i]
+    lower(resource.type) == "aws_instance"
+    lower(resource.properties.associate_public_ip_address) == "true"
+    lower(resource.properties.vpc_security_group_ids[_]) == "default"
+}
+
+aws_bool_issue["ec2_public_ip"] {
+    resource := input.resources[i]
+    lower(resource.type) == "aws_instance"
+    resource.properties.associate_public_ip_address == true
     lower(resource.properties.security_groups[_]) == "default"
 }
 
 aws_bool_issue["ec2_public_ip"] {
     resource := input.resources[i]
     lower(resource.type) == "aws_instance"
-    network_interface := resource.properties.network_interface[_]
-    network_interface.associate_public_ip_address == true
-    lower(resource.properties.security_groups[_]) == "default"
+    resource.properties.associate_public_ip_address == true
+    lower(resource.properties.vpc_security_group_ids[_]) == "default"
 }
 
 ec2_public_ip {

--- a/aws/terraform/ec2.rego
+++ b/aws/terraform/ec2.rego
@@ -67,6 +67,22 @@ aws_issue["ec2_no_vpc"] {
     count([c | network_interface.subnet_id; c := 1]) == 0
 }
 
+aws_issue["ec2_no_vpc"] {
+    resource := input.resources[i]
+    lower(resource.type) == "aws_instance"
+    count(resource.properties.subnet_id) == 0
+    network_interface := resource.properties.network_interface[_]
+    count([c | network_interface.subnet_id; c := 1]) == 0
+}
+
+aws_issue["ec2_no_vpc"] {
+    resource := input.resources[i]
+    lower(resource.type) == "aws_instance"
+    resource.properties.subnet_id == null
+    network_interface := resource.properties.network_interface[_]
+    count([c | network_interface.subnet_id; c := 1]) == 0
+}
+
 ec2_no_vpc {
     lower(input.resources[i].type) == "aws_instance"
     not aws_issue["ec2_no_vpc"]

--- a/aws/terraform/s3.rego
+++ b/aws/terraform/s3.rego
@@ -94,7 +94,16 @@ aws_issue["s3_acl_delete"] {
     stat := resource.properties.policy.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
-    lower(stat.Action) == "s3:delete"
+    startswith(lower(stat.Action),"s3:delete")
+}
+
+aws_issue["s3_acl_delete"] {
+    resource := input.resources[_]
+    lower(resource.type) == "aws_s3_bucket_policy"
+    stat := resource.properties.policy.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[_]),"s3:delete")
 }
 
 s3_acl_delete {
@@ -156,7 +165,16 @@ aws_issue["s3_acl_get"] {
     stat := resource.properties.policy.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
-    lower(stat.Action) == "s3:get"
+    startswith(lower(stat.Action),"s3:get")
+}
+
+aws_issue["s3_acl_get"] {
+    resource := input.resources[_]
+    lower(resource.type) == "aws_s3_bucket_policy"
+    stat := resource.properties.policy.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[_]),"s3:get")
 }
 
 s3_acl_get {
@@ -218,7 +236,16 @@ aws_issue["s3_acl_list"] {
     stat := resource.properties.policy.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
-    lower(stat.Action) == "s3:list"
+    startswith(lower(stat.Action),"s3:list")
+}
+
+aws_issue["s3_acl_list"] {
+    resource := input.resources[_]
+    lower(resource.type) == "aws_s3_bucket_policy"
+    stat := resource.properties.policy.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[_]),"s3:list")
 }
 
 s3_acl_list {
@@ -280,7 +307,16 @@ aws_issue["s3_acl_put"] {
     stat := resource.properties.policy.Statement[_]
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
-    lower(stat.Action) == "s3:put"
+    startswith(lower(stat.Action),"s3:put")
+}
+
+aws_issue["s3_acl_put"] {
+    resource := input.resources[_]
+    lower(resource.type) == "aws_s3_bucket_policy"
+    stat := resource.properties.policy.Statement[_]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[_]),"s3:put")
 }
 
 s3_acl_put {

--- a/aws/terraform/securitygroup.rego
+++ b/aws/terraform/securitygroup.rego
@@ -83,10 +83,10 @@ aws_issue["all"] {
 
 aws_issue["all"] {
     resource := input.resources[_]
-    lower(resource.type) == "aws_security_group_rule"
+    lower(resource.type) == "aws_security_group"
     lower(resource.properties.name) == "default"
-    ingress := resource.properties.ingress[_]
-    ingress.ipv6_cidr_blocks[_] == "::/0"
+    egress := resource.properties.egress[_]
+    egress.ipv6_cidr_blocks[_] == "::/0"
 }
 
 aws_issue["all"] {
@@ -99,10 +99,22 @@ aws_issue["all"] {
 
 aws_issue["all"] {
     resource := input.resources[_]
-    lower(resource.type) == "aws_security_group_rule"
+    lower(resource.type) == "aws_security_group"
     lower(resource.properties.name) == "default"
-    ingress := resource.properties.ingress[_]
-    ingress.cidr_blocks[_] == "0.0.0.0/0"
+    egress := resource.properties.egress[_]
+    egress.cidr_blocks[_] == "0.0.0.0/0"
+}
+
+aws_issue["all"] {
+    resource := input.resources[_]
+    lower(resource.type) == "aws_security_group_rule"
+    resource.properties.ipv6_cidr_blocks[_] == "::/0"
+}
+
+aws_issue["all"] {
+    resource := input.resources[_]
+    lower(resource.type) == "aws_security_group_rule"
+    resource.properties.cidr_blocks[_] == "0.0.0.0/0"
 }
 
 aws_issue["proto_all"] {


### PR DESCRIPTION
- Extend the scope of checking subnet_id from present in the snapshot to check null and blank value
- Fixed security group rule was not checking egress case to allowing all traffic
- Fixed terraform s3 bucket policy rule and added advanced scenario test