### PR TITLE
Added failed resource path in metadata

### DIFF
--- a/aws/iac/cloudtrail.rego
+++ b/aws/iac/cloudtrail.rego
@@ -1,4 +1,5 @@
 package rule
+default metadata = {}
 
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html
 
@@ -17,6 +18,26 @@ aws_bool_issue["ct_regions"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::cloudtrail::trail"
     not resource.Properties.IsMultiRegionTrail
+}
+
+aws_path[{"ct_regions": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    lower(resource.Properties.IsMultiRegionTrail) != "true"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "IsMultiRegionTrail"]],
+        "value": resource.Properties.IsMultiRegionTrail,
+    }
+}
+aws_path[{"ct_regions": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    not resource.Properties.IsMultiRegionTrail
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "IsMultiRegionTrail"]],
+        "value": null,
+        "function": "absent"
+    }
 }
 
 ct_regions {
@@ -66,6 +87,27 @@ aws_bool_issue["ct_log_validation"] {
     lower(resource.Type) == "aws::cloudtrail::trail"
     not resource.Properties.EnableLogFileValidation
 }
+
+aws_path[{"ct_log_validation": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    lower(resource.Properties.EnableLogFileValidation) != "true"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "EnableLogFileValidation"]],
+        "value": resource.Properties.EnableLogFileValidation,
+    }
+}
+aws_path[{"ct_log_validation": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    not resource.Properties.EnableLogFileValidation
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "EnableLogFileValidation"]],
+        "value": null,
+        "function": "absent"
+    }
+}
+
 ct_log_validation {
     lower(input.Resources[i].Type) == "aws::cloudtrail::trail"
     not aws_issue["ct_log_validation"]
@@ -116,6 +158,28 @@ aws_issue["ct_master_key"] {
     count(resource.Properties.KMSKeyId) == 0
 }
 
+aws_path[{"ct_master_key": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    not resource.Properties.KMSKeyId
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "KMSKeyId"]],
+        "value": null,
+        "function": "absent"
+    }
+}
+
+aws_path[{"ct_master_key": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    count(resource.Properties.KMSKeyId) == 0
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "KMSKeyId"]],
+        "value": count(resource.Properties.KMSKeyId),
+        "function": "count"
+    }
+}
+
 ct_master_key {
     lower(input.Resources[i].Type) == "aws::cloudtrail::trail"
     not aws_issue["ct_master_key"]
@@ -159,6 +223,38 @@ aws_issue["ct_cloudwatch"] {
     lower(resource.Type) == "aws::cloudtrail::trail"
     count(resource.Properties.CloudWatchLogsRoleArn) == 0
     count(resource.Properties.CloudWatchLogsLogGroupArn) == 0
+}
+
+aws_path[{"ct_cloudwatch": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    not resource.Properties.CloudWatchLogsRoleArn
+    not resource.Properties.CloudWatchLogsLogGroupArn
+
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "CloudWatchLogsRoleArn"],
+            ["Resources", i, "Properties", "CloudWatchLogsLogGroupArn"]
+        ],
+        "value": null,
+        "function": "absent"
+    }
+}
+
+aws_path[{"ct_cloudwatch": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    count(resource.Properties.CloudWatchLogsRoleArn) == 0
+    count(resource.Properties.CloudWatchLogsLogGroupArn) == 0
+
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "CloudWatchLogsRoleArn"],
+            ["Resources", i, "Properties", "CloudWatchLogsLogGroupArn"]
+        ],
+        "value": 0,
+        "function": "count"
+    }
 }
 
 ct_cloudwatch {

--- a/aws/iac/s3.rego
+++ b/aws/iac/s3.rego
@@ -1,4 +1,5 @@
 package rule
+default metadata = {}
 
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-policy.html
@@ -15,10 +16,32 @@ aws_attribute_absence["s3_accesslog"] {
     not resource.Properties.LoggingConfiguration.DestinationBucketName
 }
 
+aws_path[{"s3_accesslog": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    not resource.Properties.LoggingConfiguration.DestinationBucketName
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "LoggingConfiguration", "DestinationBucketName"]],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
 aws_attribute_absence["s3_accesslog"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::s3::bucket"
     not resource.Properties.LoggingConfiguration.LogFilePrefix
+}
+
+aws_path[{"s3_accesslog": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    not resource.Properties.LoggingConfiguration.LogFilePrefix
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "LoggingConfiguration", "LogFilePrefix"]],
+        "value": null,
+        "functions": "absent"
+    }
 }
 
 aws_issue["s3_accesslog"] {
@@ -27,10 +50,32 @@ aws_issue["s3_accesslog"] {
     count(resource.Properties.LoggingConfiguration.DestinationBucketName) == 0
 }
 
+aws_path[{"s3_accesslog": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    count(resource.Properties.LoggingConfiguration.DestinationBucketName) == 0
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "LoggingConfiguration", "DestinationBucketName"]],
+        "value": count(resource.Properties.LoggingConfiguration.DestinationBucketName),
+        "functions": "count"
+    }
+}
+
 aws_issue["s3_accesslog"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::s3::bucket"
     count(resource.Properties.LoggingConfiguration.LogFilePrefix) == 0
+}
+
+aws_path[{"s3_accesslog": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    count(resource.Properties.LoggingConfiguration.LogFilePrefix) == 0
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "LoggingConfiguration", "LogFilePrefix"]],
+        "value": count(resource.Properties.LoggingConfiguration.LogFilePrefix),
+        "functions": "count"
+    }
 }
 
 s3_accesslog {
@@ -66,6 +111,7 @@ s3_accesslog_metadata := {
     "Policy Help URL": "",
     "Resource Help URL": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html"
 }
+
 
 #
 # PR-AWS-0140-CFR
@@ -105,6 +151,57 @@ aws_issue["s3_acl_delete"] {
     stat.Principal == "*"
     startswith(lower(stat.Action[_]),"s3:delete")
 }
+
+aws_path[{"s3_acl_delete": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    not resource.Properties.PolicyDocument.Statement
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement"]],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
+aws_path[{"s3_acl_delete": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    lower(stat.Action[k]) == "s3:*"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+}
+
+aws_path[{"s3_acl_delete": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:delete")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action"]],
+        "value": stat.Action,
+    }
+}
+
+aws_path[{"s3_acl_delete": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[k]),"s3:delete")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+}
+
 
 s3_acl_delete {
     lower(input.Resources[i].Type) == "aws::s3::bucketpolicy"
@@ -177,6 +274,57 @@ aws_issue["s3_acl_get"] {
     lower(stat.Effect) == "allow"
     stat.Principal == "*"
     startswith(lower(stat.Action[_]),"s3:get")
+}
+
+
+aws_path[{"s3_acl_get": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    not resource.Properties.PolicyDocument.Statement
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement"]],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
+aws_path[{"s3_acl_get": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    lower(stat.Action[k]) == "s3:*"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+}
+
+aws_path[{"s3_acl_get": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:get")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action"]],
+        "value": stat.Action,
+    }
+}
+
+aws_path[{"s3_acl_get": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[k]),"s3:get")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
 }
 
 s3_acl_get {
@@ -254,6 +402,58 @@ aws_issue["s3_acl_list"] {
 
 }
 
+aws_path[{"s3_acl_list": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    not resource.Properties.PolicyDocument.Statement
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement"]],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
+aws_path[{"s3_acl_list": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    lower(stat.Action[k]) == "s3:*"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+}
+
+aws_path[{"s3_acl_list": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:list")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action"]],
+        "value": stat.Action,
+    }
+
+}
+
+aws_path[{"s3_acl_list": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[k]),"s3:list")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+
+}
+
 s3_acl_list {
     lower(input.Resources[i].Type) == "aws::s3::bucketpolicy"
     not aws_issue["s3_acl_list"]
@@ -328,6 +528,57 @@ aws_issue["s3_acl_put"] {
     startswith(lower(stat.Action[_]),"s3:put")
 }
 
+aws_path[{"s3_acl_put": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    not resource.Properties.PolicyDocument.Statement
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement"]],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
+aws_path[{"s3_acl_put": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    lower(stat.Action[k]) == "s3:*"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+}
+
+aws_path[{"s3_acl_put": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action),"s3:put")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action"]],
+        "value": stat.Action,
+    }
+
+}
+
+aws_path[{"s3_acl_put": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    stat := resource.Properties.PolicyDocument.Statement[j]
+    lower(stat.Effect) == "allow"
+    stat.Principal == "*"
+    startswith(lower(stat.Action[k]),"s3:put")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Action", k]],
+        "value": stat.Action[k],
+    }
+}
+
 s3_acl_put {
     lower(input.Resources[i].Type) == "aws::s3::bucketpolicy"
     not aws_issue["s3_acl_put"]
@@ -380,6 +631,31 @@ aws_bool_issue["s3_cloudtrail"] {
     not resource.Properties.IsLogging
 }
 
+aws_path[{"s3_cloudtrail": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    lower(resource.Properties.IsLogging) == "false"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "IsLogging"],
+        ],
+        "value": resource.Properties.IsLogging,
+    }
+}
+
+aws_path[{"s3_cloudtrail": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::cloudtrail::trail"
+    not resource.Properties.IsLogging
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "IsLogging"],
+        ],
+        "value": null,
+        "function": "absent"
+    }
+}
+
 s3_cloudtrail {
     lower(input.Resources[i].Type) == "aws::cloudtrail::trail"
     not aws_issue["s3_cloudtrail"]
@@ -430,6 +706,27 @@ aws_issue["s3_versioning"] {
     lower(resource.Properties.VersioningConfiguration.Status) != "enabled"
 }
 
+aws_path[{"s3_versioning": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    not resource.Properties.VersioningConfiguration.Status
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "VersioningConfiguration", "Status"]],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
+aws_path[{"s3_versioning": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    lower(resource.Properties.VersioningConfiguration.Status) != "enabled"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "VersioningConfiguration", "Status"]],
+        "value": resource.Properties.VersioningConfiguration.Status,
+    }
+}
+
 s3_versioning {
     lower(input.Resources[i].Type) == "aws::s3::bucket"
     not aws_issue["s3_versioning"]
@@ -474,6 +771,17 @@ aws_issue["s3_public_acl"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::s3::bucket"
     resource.Properties.AccessControl == "PublicRead"
+}
+
+aws_path[{"s3_public_acl": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    lower(resource.Properties.AccessControl) == "publicread"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "AccessControl"]],
+        "value": resource.Properties.AccessControl,
+        "functions": "absent"
+    }
 }
 
 s3_public_acl {
@@ -547,6 +855,81 @@ aws_bool_issue["s3_transport"] {
     not statement.Condition.Bool["aws:SecureTransport"]
 }
 
+aws_path[{"s3_transport": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    statement := resource.Properties.PolicyDocument.Statement[j]
+    not statement.Condition.StringLike
+    not statement.Condition.Bool
+    
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "PolicyDocument", "Statement", j, "StringLike"],
+            ["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Bool"]
+        ],
+        "value": null,
+        "functions": "absent"
+    }
+}
+
+aws_path[{"s3_transport": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    statement := resource.Properties.PolicyDocument.Statement[j]
+    statement.Condition.StringLike
+    lower(statement.Condition.StringLike["aws:SecureTransport"]) != "true"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "PolicyDocument", "Statement", j, "StringLike", "aws:SecureTransport"],
+        ],
+        "value": statement.Condition.StringLike["aws:SecureTransport"]
+    }
+}
+
+aws_path[{"s3_transport": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    statement := resource.Properties.PolicyDocument.Statement[j]
+    statement.Condition.Bool
+    lower(statement.Condition.Bool["aws:SecureTransport"]) != "true"
+     metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Bool", "aws:SecureTransport"],
+        ],
+        "value": statement.Condition.Bool["aws:SecureTransport"]
+    }
+}
+
+aws_path[{"s3_transport": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    statement := resource.Properties.PolicyDocument.Statement[j]
+    statement.Condition.StringLike
+    not statement.Condition.StringLike["aws:SecureTransport"]
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "PolicyDocument", "Statement", j, "StringLike", "aws:SecureTransport"],
+        ],
+        "value": null,
+        "function": "absent"
+    }
+}
+
+aws_path[{"s3_transport": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucketpolicy"
+    statement := resource.Properties.PolicyDocument.Statement[j]
+    statement.Condition.Bool
+    not statement.Condition.Bool["aws:SecureTransport"]
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "PolicyDocument", "Statement", j, "Bool", "aws:SecureTransport"],
+        ],
+        "value": null,
+        "function": "absent"
+    }
+}
+
 s3_transport {
     lower(input.Resources[i].Type) == "aws::s3::bucketpolicy"
     not aws_issue["s3_transport"]
@@ -592,6 +975,18 @@ aws_issue["s3_auth_acl"] {
     resource.Properties.AccessControl == "AuthenticatedRead"
 }
 
+aws_path[{"s3_auth_acl": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    lower(resource.Properties.AccessControl) == "authenticatedread"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "AccessControl"],
+        ],
+        "value": resource.Properties.AccessControl,
+    }
+}
+
 s3_auth_acl {
     lower(input.Resources[i].Type) == "aws::s3::bucket"
     not aws_issue["s3_auth_acl"]
@@ -635,6 +1030,30 @@ aws_issue["s3_public_access"] {
     resource.Properties.AccessControl == "PublicReadWrite"
 }
 
+aws_path[{"s3_public_access": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    lower(resource.Properties.AccessControl) == "publicread"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "AccessControl"],
+        ],
+        "value": resource.Properties.AccessControl,
+    }
+}
+
+aws_path[{"s3_public_access": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    lower(resource.Properties.AccessControl) == "publicreadwrite"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "AccessControl"],
+        ],
+        "value": resource.Properties.AccessControl,
+    }
+}
+
 s3_public_access {
     lower(input.Resources[i].Type) == "aws::s3::bucket"
     not aws_issue["s3_public_access"]
@@ -672,6 +1091,17 @@ aws_issue["s3_encryption"] {
     not resource.Properties.BucketEncryption.ServerSideEncryptionConfiguration
 }
 
+aws_path["s3_encryption"] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "BucketEncryption", "ServerSideEncryptionConfiguration"],
+        ],
+        "value": resource.Properties.AccessControl,
+    }
+}
+
 s3_encryption {
     lower(input.Resources[i].Type) == "aws::s3::bucket"
     not aws_issue["s3_encryption"]
@@ -707,6 +1137,18 @@ aws_issue["s3_website"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::s3::bucket"
     resource.Properties.WebsiteConfiguration
+}
+
+aws_path[{"s3_website": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    resource.Properties.WebsiteConfiguration
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "WebsiteConfiguration"],
+        ],
+        "value": resource.Properties.WebsiteConfiguration,
+    }
 }
 
 s3_website {
@@ -747,6 +1189,21 @@ aws_issue["s3_cors"] {
     cors_rule := resource.Properties.CorsConfiguration.CorsRules[_]
     cors_rule.AllowedHeaders[_] == "*"
     cors_rule.AllowedMethods[_] == "*"
+}
+
+aws_path[{"s3_cors": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::s3::bucket"
+    cors_rule := resource.Properties.CorsConfiguration.CorsRules[j]
+    cors_rule.AllowedHeaders[k] == "*"
+    cors_rule.AllowedMethods[l] == "*"
+    metadata := {
+        "resource_path": [
+            ["Resources", i, "Properties", "CorsConfiguration", "CorsRules", j, "AllowedHeaders", k],
+            ["Resources", i, "Properties", "CorsConfiguration", "CorsRules", j, "AllowedHeaders", l]
+        ],
+        "value": "*",
+    }
 }
 
 s3_cors {

--- a/aws/iac/sns.rego
+++ b/aws/iac/sns.rego
@@ -1,4 +1,5 @@
 package rule
+default metadata = {}
 
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html
@@ -19,6 +20,27 @@ aws_issue["sns_protocol"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::sns::subscription"
     lower(resource.Properties.Protocol) == "http"
+}
+
+aws_path[{"sns_protocol": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::sns::subscription"
+    not resource.Properties.Protocol
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "Protocol"]],
+        "value": null,
+        "function": "absent"
+    }
+}
+
+aws_path[{"sns_protocol": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::sns::subscription"
+    lower(resource.Properties.Protocol) == "http"
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "Protocol"]],
+        "value": resource.Properties.Protocol,
+    }
 }
 
 sns_protocol {
@@ -67,6 +89,16 @@ aws_issue["sns_encrypt_key"] {
     contains(lower(resource.Properties.KmsMasterKeyId), "alias/aws/sns")
 }
 
+aws_path[{"sns_encrypt_key": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::sns::topic"
+    contains(lower(resource.Properties.KmsMasterKeyId), "alias/aws/sns")
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "KmsMasterKeyId"]],
+        "value": resource.Properties.KmsMasterKeyId,
+    }
+}
+
 sns_encrypt_key {
     lower(input.Resources[i].Type) == "aws::sns::topic"
     not aws_issue["sns_encrypt_key"]
@@ -108,6 +140,28 @@ aws_issue["sns_encrypt"] {
     resource := input.Resources[i]
     lower(resource.Type) == "aws::sns::topic"
     count(resource.Properties.KmsMasterKeyId) == 0
+}
+
+aws_path[{"sns_encrypt": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::sns::topic"
+    not resource.Properties.KmsMasterKeyId
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "KmsMasterKeyId"]],
+        "value": null,
+        "function": "absent"
+    }
+}
+
+aws_path[{"sns_encrypt": metadata}] {
+    resource := input.Resources[i]
+    lower(resource.Type) == "aws::sns::topic"
+    count(resource.Properties.KmsMasterKeyId) == 0
+    metadata := {
+        "resource_path": [["Resources", i, "Properties", "KmsMasterKeyId"]],
+        "value": count(resource.Properties.KmsMasterKeyId),
+        "function": "count"
+    }
 }
 
 sns_encrypt {


### PR DESCRIPTION
Separate metadata from rule validation and create a new rule which returns the path of the failed resources.
Updated files:

- S3.rego
- SNS.rego
- Cloudtrail.rego