### PR TITLE
K8s review

### DIFF
--- a/kubernetes/iac/networkPolicy.rego
+++ b/kubernetes/iac/networkPolicy.rego
@@ -11,9 +11,25 @@ k8s_issue["empty_ingress"] {
     not input.spec.ingress
 }
 
+source_path[{"empty_ingress":metadata}] {
+    lower(input.kind) == "networkpolicy"
+    not input.spec.ingress
+    metadata:= {
+        "resource_path": [["spec","ingress"]]
+    }
+}
+
 k8s_issue["empty_ingress"] {
     lower(input.kind) == "networkpolicy"
     count(input.spec.ingress) == 0
+}
+
+source_path[{"empty_ingress":metadata}] {
+    lower(input.kind) == "networkpolicy"
+    count(input.spec.ingress) == 0
+    metadata:= {
+        "resource_path": [["spec","ingress"]]
+    }
 }
 
 empty_ingress {

--- a/kubernetes/iac/pod.rego
+++ b/kubernetes/iac/pod.rego
@@ -7,6 +7,19 @@ package rule
 default run_pod_as_root = null
 
 k8s_issue["run_pod_as_root"] {
+    lower(input.kind) == "pod"
+    input.spec.template.spec.containers[_].securityContext.runAsNonRoot == false
+}
+
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "pod"
+    input.spec.template.spec.containers[i].securityContext.runAsNonRoot == false
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsNonRoot"]]
+    }
+}
+
+k8s_issue["run_pod_as_root"] {
     lower(input.kind) == "daemonset"
     input.spec.template.spec.containers[_].securityContext.runAsNonRoot == false
 }
@@ -127,6 +140,19 @@ run_pod_as_root_metadata := {
 default run_privileged_pod = null
 
 k8s_issue["run_privileged_pod"] {
+    lower(input.kind) == "pod"
+    input.spec.template.spec.containers[_].securityContext.privileged == true
+}
+
+source_path[{"run_privileged_pod":metadata}] {
+    lower(input.kind) == "pod"
+    input.spec.template.spec.containers[i].securityContext.privileged == true
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","privileged"]]
+    }
+}
+
+k8s_issue["run_privileged_pod"] {
     lower(input.kind) == "daemonset"
     input.spec.template.spec.containers[_].securityContext.privileged == true
 }
@@ -205,6 +231,19 @@ run_privileged_pod_metadata := {
 #
 
 default pod_default_ns = null
+
+k8s_issue["pod_default_ns"] {
+    lower(input.kind) == "pod"
+    input.namespace == "default"
+}
+
+source_path[{"pod_default_ns":metadata}] {
+    lower(input.kind) == "pod"
+    input.namespace == "default"
+    metadata:= {
+        "resource_path": [["namespace"]]
+    }
+}
 
 k8s_issue["pod_default_ns"] {
     lower(input.kind) == "daemonset"
@@ -287,6 +326,19 @@ pod_default_ns_metadata := {
 default hostpath_mount = null
 
 k8s_issue["hostpath_mount"] {
+    lower(input.kind) == "pod"
+    count(input.spec.template.spec.volumes[_].hostPath) > 0
+}
+
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "pod"
+    count(input.spec.template.spec.volumes[i].hostPath) > 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","volumes",i,"hostPath"]]
+    }
+}
+
+k8s_issue["hostpath_mount"] {
     lower(input.kind) == "daemonset"
     count(input.spec.template.spec.volumes[_].hostPath) > 0
 }
@@ -365,6 +417,21 @@ hostpath_mount_metadata := {
 #
 
 default pod_selinux = null
+
+k8s_issue["pod_selinux"] {
+    lower(input.kind) == "pod"
+    container := input.spec.template.spec.containers[_]
+    not container.securityContext.seLinuxOptions
+}
+
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "pod"
+    container := input.spec.template.spec.containers[i]
+    not container.securityContext.seLinuxOptions
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","seLinuxOptions"]]
+    }
+}
 
 k8s_issue["pod_selinux"] {
     lower(input.kind) == "daemonset"

--- a/kubernetes/iac/pod.rego
+++ b/kubernetes/iac/pod.rego
@@ -11,14 +11,38 @@ k8s_issue["run_pod_as_root"] {
     input.spec.template.spec.containers[_].securityContext.runAsNonRoot == false
 }
 
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "daemonset"
+    input.spec.template.spec.containers[i].securityContext.runAsNonRoot == false
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsNonRoot"]]
+    }
+}
+
 k8s_issue["run_pod_as_root"] {
     lower(input.kind) == "daemonset"
     input.spec.template.spec.containers[_].securityContext.runAsUser == 0
 }
 
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "daemonset"
+    input.spec.template.spec.containers[i].securityContext.runAsUser == 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsUser"]]
+    }
+}
+
 k8s_issue["run_pod_as_root"] {
     lower(input.kind) == "deployment"
     input.spec.template.spec.containers[_].securityContext.runAsNonRoot == false
+}
+
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "deployment"
+    input.spec.template.spec.containers[i].securityContext.runAsNonRoot == false
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsNonRoot"]]
+    }
 }
 
 k8s_issue["run_pod_as_root"] {
@@ -26,14 +50,39 @@ k8s_issue["run_pod_as_root"] {
     input.spec.template.spec.containers[_].securityContext.runAsUser == 0
 }
 
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "deployment"
+    input.spec.template.spec.containers[i].securityContext.runAsUser == 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsUser"]]
+    }
+}
+
 k8s_issue["run_pod_as_root"] {
     lower(input.kind) == "statefulset"
     input.spec.template.spec.containers[_].securityContext.runAsNonRoot == false
 }
 
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "statefulset"
+    input.spec.template.spec.containers[i].securityContext.runAsNonRoot == false
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsNonRoot"]]
+    }
+}
+
+
 k8s_issue["run_pod_as_root"] {
     lower(input.kind) == "statefulset"
     input.spec.template.spec.containers[_].securityContext.runAsUser == 0
+}
+
+source_path[{"run_pod_as_root":metadata}] {
+    lower(input.kind) == "statefulset"
+    input.spec.template.spec.containers[i].securityContext.runAsUser == 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","runAsUser"]]
+    }
 }
 
 run_pod_as_root {
@@ -82,14 +131,38 @@ k8s_issue["run_privileged_pod"] {
     input.spec.template.spec.containers[_].securityContext.privileged == true
 }
 
+source_path[{"run_privileged_pod":metadata}] {
+    lower(input.kind) == "daemonset"
+    input.spec.template.spec.containers[i].securityContext.privileged == true
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","privileged"]]
+    }
+}
+
 k8s_issue["run_privileged_pod"] {
     lower(input.kind) == "deployment"
     input.spec.template.spec.containers[_].securityContext.privileged == true
 }
 
+source_path[{"run_privileged_pod":metadata}] {
+    lower(input.kind) == "deployment"
+    input.spec.template.spec.containers[i].securityContext.privileged == true
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","privileged"]]
+    }
+}
+
 k8s_issue["run_privileged_pod"] {
     lower(input.kind) == "statefulset"
     input.spec.template.spec.containers[_].securityContext.privileged == true
+}
+
+source_path[{"run_privileged_pod":metadata}] {
+    lower(input.kind) == "statefulset"
+    input.spec.template.spec.containers[i].securityContext.privileged == true
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","privileged"]]
+    }
 }
 
 run_privileged_pod {
@@ -138,14 +211,38 @@ k8s_issue["pod_default_ns"] {
     input.namespace == "default"
 }
 
+source_path[{"pod_default_ns":metadata}] {
+    lower(input.kind) == "daemonset"
+    input.namespace == "default"
+    metadata:= {
+        "resource_path": [["namespace"]]
+    }
+}
+
 k8s_issue["pod_default_ns"] {
     lower(input.kind) == "deployment"
     input.namespace == "default"
 }
 
+source_path[{"pod_default_ns":metadata}] {
+    lower(input.kind) == "deployment"
+    input.namespace == "default"
+    metadata:= {
+        "resource_path": [["namespace"]]
+    }
+}
+
 k8s_issue["pod_default_ns"] {
     lower(input.kind) == "statefulset"
     input.namespace == "default"
+}
+
+source_path[{"pod_default_ns":metadata}] {
+    lower(input.kind) == "statefulset"
+    input.namespace == "default"
+    metadata:= {
+        "resource_path": [["namespace"]]
+    }
 }
 
 pod_default_ns {
@@ -194,14 +291,38 @@ k8s_issue["hostpath_mount"] {
     count(input.spec.template.spec.volumes[_].hostPath) > 0
 }
 
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "daemonset"
+    count(input.spec.template.spec.volumes[i].hostPath) > 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","volumes",i,"hostPath"]]
+    }
+}
+
 k8s_issue["hostpath_mount"] {
     lower(input.kind) == "deployment"
     count(input.spec.template.spec.volumes[_].hostPath) > 0
 }
 
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "deployment"
+    count(input.spec.template.spec.volumes[i].hostPath) > 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","volumes",i,"hostPath"]]
+    }
+}
+
 k8s_issue["hostpath_mount"] {
     lower(input.kind) == "statefulset"
     count(input.spec.template.spec.volumes[_].hostPath) > 0
+}
+
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "statefulset"
+    count(input.spec.template.spec.volumes[i].hostPath) > 0
+    metadata:= {
+        "resource_path": [["spec","template","spec","volumes",i,"hostPath"]]
+    }
 }
 
 hostpath_mount {
@@ -251,16 +372,43 @@ k8s_issue["pod_selinux"] {
     not container.securityContext.seLinuxOptions
 }
 
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "daemonset"
+    container := input.spec.template.spec.containers[i]
+    not container.securityContext.seLinuxOptions
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","seLinuxOptions"]]
+    }
+}
+
 k8s_issue["pod_selinux"] {
     lower(input.kind) == "deployment"
     container := input.spec.template.spec.containers[_]
     not container.securityContext.seLinuxOptions
 }
 
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "deployment"
+    container := input.spec.template.spec.containers[i]
+    not container.securityContext.seLinuxOptions
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","seLinuxOptions"]]
+    }
+}
+
 k8s_issue["pod_selinux"] {
     lower(input.kind) == "statefulset"
     container := input.spec.template.spec.containers[_]
     not container.securityContext.seLinuxOptions
+}
+
+source_path[{"hostpath_mount":metadata}] {
+    lower(input.kind) == "statefulset"
+    container := input.spec.template.spec.containers[i]
+    not container.securityContext.seLinuxOptions
+    metadata:= {
+        "resource_path": [["spec","template","spec","containers",i,"securityContext","seLinuxOptions"]]
+    }
 }
 
 pod_selinux {

--- a/kubernetes/iac/podSecurityPolicy.rego
+++ b/kubernetes/iac/podSecurityPolicy.rego
@@ -11,6 +11,14 @@ k8s_issue["privileged"] {
     input.spec.privileged
 }
 
+source_path[{"privileged":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    input.spec.privileged
+    metadata:= {
+        "resource_path": [["spec","privileged"]]
+    }
+}
+
 privileged {
     lower(input.kind) == "podsecuritypolicy"
     not k8s_issue["privileged"]
@@ -47,10 +55,27 @@ k8s_issue["run_as_root"] {
     lower(input.spec.runAsUser.rule) == "runasany"
 }
 
+source_path[{"run_as_root":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    lower(input.spec.runAsUser.rule) == "runasany"
+    metadata:= {
+        "resource_path": [["spec","runAsUser","rule"]]
+    }
+}
+
 k8s_issue["run_as_root"] {
     lower(input.kind) == "podsecuritypolicy"
     lower(input.spec.runAsUser.rule) == "mustrunas"
     input.spec.runAsUser.ranges[_].min == 0
+}
+
+source_path[{"run_as_root":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    lower(input.spec.runAsUser.rule) == "mustrunas"
+    input.spec.runAsUser.ranges[i].min == 0
+    metadata:= {
+        "resource_path": [["spec","runAsUser","ranges",i,"min"]]
+    }
 }
 
 run_as_root {
@@ -89,11 +114,29 @@ k8s_issue["drop_capabilities"] {
     not input.spec.requiredDropCapabilities
 }
 
+source_path[{"drop_capabilities":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    not input.spec.requiredDropCapabilities
+    metadata:= {
+        "resource_path": [["spec","requiredDropCapabilities"]]
+    }
+}
+
 k8s_issue["drop_capabilities"] {
     lower(input.kind) == "podsecuritypolicy"
     rdc := input.spec.requiredDropCapabilities
     count([c | rdc[_] == "NET_RAW"; c := 1]) == 0
     count([c | rdc[_] == "ALL"; c := 1]) == 0
+}
+
+source_path[{"drop_capabilities":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    rdc := input.spec.requiredDropCapabilities
+    count([c | rdc[_] == "NET_RAW"; c := 1]) == 0
+    count([c | rdc[_] == "ALL"; c := 1]) == 0
+    metadata:= {
+        "resource_path": [["spec","requiredDropCapabilities",i]]
+    }
 }
 
 drop_capabilities {
@@ -132,6 +175,14 @@ k8s_issue["host_ipc"] {
     input.spec.hostIPC == true
 }
 
+source_path[{"host_ipc":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    input.spec.hostIPC == true
+    metadata:= {
+        "resource_path": [["spec","hostIPC"]]
+    }
+}
+
 host_ipc {
     lower(input.kind) == "podsecuritypolicy"
     not k8s_issue["host_ipc"]
@@ -166,6 +217,14 @@ default host_network = null
 k8s_issue["host_network"] {
     lower(input.kind) == "podsecuritypolicy"
     input.spec.hostNetwork == true
+}
+
+source_path[{"host_network":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    input.spec.hostNetwork == true
+    metadata:= {
+        "resource_path": [["spec","hostNetwork"]]
+    }
 }
 
 host_network {
@@ -204,6 +263,14 @@ k8s_issue["host_pid"] {
     input.spec.hostPID == true
 }
 
+source_path[{"host_pid":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    input.spec.hostPID == true
+    metadata:= {
+        "resource_path": [["spec","hostPID"]]
+    }
+}
+
 host_pid {
     lower(input.kind) == "podsecuritypolicy"
     not k8s_issue["host_pid"]
@@ -237,7 +304,15 @@ default privilege_escalation = null
 
 k8s_issue["privilege_escalation"] {
     lower(input.kind) == "podsecuritypolicy"
-    input.spec.hostPID == true
+    input.spec.allowPrivilegeEscalation == true
+}
+
+source_path[{"privilege_escalation":metadata}] {
+    lower(input.kind) == "podsecuritypolicy"
+    input.spec.allowPrivilegeEscalation == true
+    metadata:= {
+        "resource_path": [["spec","allowPrivilegeEscalation"]]
+    }
 }
 
 privilege_escalation {

--- a/kubernetes/iac/podSecurityPolicy.rego
+++ b/kubernetes/iac/podSecurityPolicy.rego
@@ -72,7 +72,7 @@ k8s_issue["run_as_root"] {
 source_path[{"run_as_root":metadata}] {
     lower(input.kind) == "podsecuritypolicy"
     lower(input.spec.runAsUser.rule) == "mustrunas"
-    input.spec.runAsUser.ranges[i].min == 0
+    input.spec.runAsUser.ranges[_].min == 0
     metadata:= {
         "resource_path": [["spec","runAsUser","ranges",i,"min"]]
     }
@@ -135,7 +135,7 @@ source_path[{"drop_capabilities":metadata}] {
     count([c | rdc[_] == "NET_RAW"; c := 1]) == 0
     count([c | rdc[_] == "ALL"; c := 1]) == 0
     metadata:= {
-        "resource_path": [["spec","requiredDropCapabilities",i]]
+        "resource_path": [["spec","requiredDropCapabilities"]]
     }
 }
 

--- a/kubernetes/iac/podSecurityPolicy.rego
+++ b/kubernetes/iac/podSecurityPolicy.rego
@@ -72,7 +72,7 @@ k8s_issue["run_as_root"] {
 source_path[{"run_as_root":metadata}] {
     lower(input.kind) == "podsecuritypolicy"
     lower(input.spec.runAsUser.rule) == "mustrunas"
-    input.spec.runAsUser.ranges[_].min == 0
+    input.spec.runAsUser.ranges[i].min == 0
     metadata:= {
         "resource_path": [["spec","runAsUser","ranges",i,"min"]]
     }

--- a/kubernetes/iac/role.rego
+++ b/kubernetes/iac/role.rego
@@ -11,9 +11,25 @@ k8s_issue["rbac_secrets"] {
     input.rules[_].resources[_] == "secrets"
 }
 
+source_path[{"rbac_secrets":metadata}] {
+    lower(input.kind) == "clusterrole"
+    input.rules[i].resources[j] == "secrets"
+    metadata:= {
+        "resource_path": [["rules",i,"resources",j]]
+    }
+}
+
 k8s_issue["rbac_secrets"] {
     lower(input.kind) == "clusterrole"
     regex.match(".*\\*.*", input.rules[_].resources[_])
+}
+
+source_path[{"rbac_secrets":metadata}] {
+    lower(input.kind) == "clusterrole"
+    regex.match(".*\\*.*", input.rules[i].resources[j])
+    metadata:= {
+        "resource_path": [["rules",i,"resources",j]]
+    }
 }
 
 k8s_issue["rbac_secrets"] {
@@ -21,9 +37,25 @@ k8s_issue["rbac_secrets"] {
     input.rules[_].resources[_] == "secrets"
 }
 
+source_path[{"rbac_secrets":metadata}] {
+    lower(input.kind) == "role"
+    input.rules[i].resources[j] == "secrets"
+    metadata:= {
+        "resource_path": [["rules",i,"resources",j]]
+    }
+}
+
 k8s_issue["rbac_secrets"] {
     lower(input.kind) == "role"
     regex.match(".*\\*.*", input.rules[_].resources[_])
+}
+
+source_path[{"rbac_secrets":metadata}] {
+    lower(input.kind) == "role"
+    regex.match(".*\\*.*", input.rules[i].resources[j])
+    metadata:= {
+        "resource_path": [["rules",i,"resources",j]]
+    }
 }
 
 rbac_secrets {
@@ -67,14 +99,38 @@ k8s_issue["rbac_wildcard"] {
     regex.match(".*\\*.*", input.rules[_].resources[_])
 }
 
+source_path[{"rbac_wildcard":metadata}] {
+    lower(input.kind) == "clusterrole"
+    regex.match(".*\\*.*", input.rules[i].resources[j])
+    metadata:= {
+        "resource_path": [["rules",i,"resources",j]]
+    }
+}
+
 k8s_issue["rbac_wildcard"] {
     lower(input.kind) == "clusterrole"
     regex.match(".*\\*.*", input.rules[_].apiGroups[_])
 }
 
+source_path[{"rbac_wildcard":metadata}] {
+    lower(input.kind) == "clusterrole"
+    regex.match(".*\\*.*", input.rules[i].apiGroups[j])
+    metadata:= {
+        "resource_path": [["rules",i,"apiGroups",j]]
+    }
+}
+
 k8s_issue["rbac_wildcard"] {
     lower(input.kind) == "clusterrole"
     regex.match(".*\\*.*", input.rules[_].verbs[_])
+}
+
+source_path[{"rbac_wildcard":metadata}] {
+    lower(input.kind) == "clusterrole"
+    regex.match(".*\\*.*", input.rules[i].verbs[j])
+    metadata:= {
+        "resource_path": [["rules",i,"verbs",j]]
+    }
 }
 
 k8s_issue["rbac_wildcard"] {
@@ -82,14 +138,38 @@ k8s_issue["rbac_wildcard"] {
     regex.match(".*\\*.*", input.rules[_].resources[_])
 }
 
+source_path[{"rbac_wildcard":metadata}] {
+    lower(input.kind) == "role"
+    regex.match(".*\\*.*", input.rules[i].resources[j])
+    metadata:= {
+        "resource_path": [["rules",i,"resources",j]]
+    }
+}
+
 k8s_issue["rbac_wildcard"] {
     lower(input.kind) == "role"
     regex.match(".*\\*.*", input.rules[_].apiGroups[_])
 }
 
+source_path[{"rbac_wildcard":metadata}] {
+    lower(input.kind) == "role"
+    regex.match(".*\\*.*", input.rules[i].apiGroups[j])
+    metadata:= {
+        "resource_path": [["rules",i,"apiGroups",j]]
+    }
+}
+
 k8s_issue["rbac_wildcard"] {
     lower(input.kind) == "role"
     regex.match(".*\\*.*", input.rules[_].verbs[_])
+}
+
+source_path[{"rbac_wildcard":metadata}] {
+    lower(input.kind) == "role"
+    regex.match(".*\\*.*", input.rules[i].verbs[j])
+    metadata:= {
+        "resource_path": [["rules",i,"verbs",j]]
+    }
 }
 
 rbac_wildcard {

--- a/kubernetes/iac/roleBinding.rego
+++ b/kubernetes/iac/roleBinding.rego
@@ -12,16 +12,35 @@ k8s_issue["default_role"] {
     lower(input.roleRef.name) == "default"
 }
 
+source_path[{"default_role":metadata}] {
+    lower(input.kind) == "clusterrolebinding"
+    lower(input.roleRef.kind) == "role"
+    lower(input.roleRef.name) == "default"
+    metadata:= {
+        "resource_path": [["roleRef","name"]]
+    }
+}
+
 k8s_issue["default_role"] {
     lower(input.kind) == "rolebinding"
     lower(input.roleRef.kind) == "role"
     lower(input.roleRef.name) == "default"
 }
 
+source_path[{"default_role":metadata}] {
+    lower(input.kind) == "rolebinding"
+    lower(input.roleRef.kind) == "role"
+    lower(input.roleRef.name) == "default"
+    metadata:= {
+        "resource_path": [["roleRef","name"]]
+    }
+}
+
 default_role {
     lower(input.kind) == "clusterrolebinding"
     not k8s_issue["default_role"]
 }
+
 
 default_role {
     lower(input.kind) == "rolebinding"
@@ -60,10 +79,28 @@ k8s_issue["admin_role"] {
     lower(input.roleRef.name) == "cluster-admin"
 }
 
+source_path[{"admin_role":metadata}] {
+    lower(input.kind) == "clusterrolebinding"
+    lower(input.roleRef.kind) == "role"
+    lower(input.roleRef.name) == "cluster-admin"
+    metadata:= {
+        "resource_path": [["roleRef","name"]]
+    }
+}
+
 k8s_issue["admin_role"] {
     lower(input.kind) == "rolebinding"
     lower(input.roleRef.kind) == "role"
     lower(input.roleRef.name) == "cluster-admin"
+}
+
+source_path[{"admin_role":metadata}] {
+    lower(input.kind) == "rolebinding"
+    lower(input.roleRef.kind) == "role"
+    lower(input.roleRef.name) == "cluster-admin"
+    metadata:= {
+        "resource_path": [["roleRef","name"]]
+    }
 }
 
 admin_role {

--- a/kubernetes/iac/serviceAccount.rego
+++ b/kubernetes/iac/serviceAccount.rego
@@ -8,7 +8,32 @@ default sa_token = null
 
 k8s_issue["sa_token"] {
     lower(input.kind) == "serviceaccount"
+    lower(input.metadata.name) == "default"
     input.automountServiceAccountToken == true
+}
+
+source_path[{"sa_token":metadata}] {
+    lower(input.kind) == "serviceaccount"
+    lower(input.metadata.name) == "default"
+    input.automountServiceAccountToken == true
+    metadata:= {
+        "resource_path": [["automountServiceAccountToken"]]
+    }
+}
+
+k8s_issue["sa_token"] {
+    lower(input.kind) == "serviceaccount"
+    lower(input.metadata.name) == "default"
+    lower(input.automountServiceAccountToken) == "true"
+}
+
+source_path[{"sa_token":metadata}] {
+    lower(input.kind) == "serviceaccount"
+    lower(input.metadata.name) == "default"
+    lower(input.automountServiceAccountToken) == "true"
+    metadata:= {
+        "resource_path": [["automountServiceAccountToken"]]
+    }
 }
 
 sa_token {
@@ -20,7 +45,7 @@ sa_token = false {
     k8s_issue["sa_token"]
 }
 
-sa_token_err = "PR-K8S-0035-DCL: The default namespace should not be used" {
+sa_token_err = "PR-K8S-0035-DCL: Ensure That Default Service Accounts Are Not Actively Used" {
     k8s_issue["sa_token"]
 }
 
@@ -29,8 +54,8 @@ sa_token_metadata := {
     "Type": "IaC",
     "Product": "Kubernetes",
     "Language": "K8s DL",
-    "Policy Title": "The default namespace should not be used ",
-    "Policy Description": "The default namespace should not be used ",
+    "Policy Title": "Ensure That Default Service Accounts Are Not Actively Used ",
+    "Policy Description": "The default service account should not be used to ensure that rights granted to applications can be more easily audited and reviewed.",
     "Resource Type": "serviceaccount",
     "Policy Help URL": "",
     "Resource Help URL": ""


### PR DESCRIPTION
Here is log from prancer:
```
/prancer # prancer --db NONE --crawler --compliance scenario-kubernetes-remote
2021-11-12 00:23:15,423 - 	 LOCATION: /prancer/./validation/
2021-11-12 00:23:15,423 - 	 COLLECTION: /prancer/./validation/scenario-kubernetes-remote
2021-11-12 00:23:15,427 - 	 LOCATION: /prancer/./validation/
2021-11-12 00:23:15,428 - 	 COLLECTION: /prancer/./validation/scenario-kubernetes-remote
2021-11-12 00:23:19,409 - 	 LOCATION: /prancer/./validation/
2021-11-12 00:23:19,409 - 	 COLLECTION: /prancer/./validation/scenario-kubernetes-remote
2021-11-12 00:23:19,519 - SNAPSHOTS COMPLETE:
2021-11-12 00:23:19,548 - 	TESTID: TEST_NETWORK_POLICY
2021-11-12 00:23:19,548 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT17
2021-11-12 00:23:19,549 - 		PATHS: 
2021-11-12 00:23:19,549 - 			 /network/network-policy.yaml
2021-11-12 00:23:19,549 - 		TITLE: Restrict Traffic Among Pods with a Network Policy
2021-11-12 00:23:19,549 - 		RULE: file(networkPolicy.rego)
2021-11-12 00:23:19,549 - 		RESULT: passed
2021-11-12 00:23:19,573 - 	TESTID: TEST_POD_1
2021-11-12 00:23:19,574 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT1
2021-11-12 00:23:19,574 - 		PATHS: 
2021-11-12 00:23:19,574 - 			 /deployment/deployment-definition.yaml
2021-11-12 00:23:19,574 - 		TITLE: Do not admit root containers
2021-11-12 00:23:19,574 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,574 - 		RESULT: passed
2021-11-12 00:23:19,603 - 	TESTID: TEST_POD_1
2021-11-12 00:23:19,604 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT14
2021-11-12 00:23:19,604 - 		PATHS: 
2021-11-12 00:23:19,604 - 			 /test-multi-yaml/multiple-yamls/multiple-helm-response_multiple_yaml_2.yaml
2021-11-12 00:23:19,604 - 		TITLE: Do not admit root containers
2021-11-12 00:23:19,604 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,604 - 		RESULT: passed
2021-11-12 00:23:19,630 - 	TESTID: TEST_POD_2
2021-11-12 00:23:19,630 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT1
2021-11-12 00:23:19,630 - 		PATHS: 
2021-11-12 00:23:19,630 - 			 /deployment/deployment-definition.yaml
2021-11-12 00:23:19,630 - 		TITLE: Ensure that Containers are not running in privileged mode
2021-11-12 00:23:19,631 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,631 - 		RESULT: passed
2021-11-12 00:23:19,663 - 	TESTID: TEST_POD_2
2021-11-12 00:23:19,663 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT14
2021-11-12 00:23:19,663 - 		PATHS: 
2021-11-12 00:23:19,663 - 			 /test-multi-yaml/multiple-yamls/multiple-helm-response_multiple_yaml_2.yaml
2021-11-12 00:23:19,663 - 		TITLE: Ensure that Containers are not running in privileged mode
2021-11-12 00:23:19,663 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,664 - 		RESULT: passed
2021-11-12 00:23:19,701 - 	TESTID: TEST_POD_3
2021-11-12 00:23:19,701 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT1
2021-11-12 00:23:19,701 - 		PATHS: 
2021-11-12 00:23:19,701 - 			 /deployment/deployment-definition.yaml
2021-11-12 00:23:19,702 - 		TITLE: The default namespace should not be used
2021-11-12 00:23:19,702 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,702 - 		RESULT: passed
2021-11-12 00:23:19,735 - 	TESTID: TEST_POD_3
2021-11-12 00:23:19,736 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT14
2021-11-12 00:23:19,736 - 		PATHS: 
2021-11-12 00:23:19,736 - 			 /test-multi-yaml/multiple-yamls/multiple-helm-response_multiple_yaml_2.yaml
2021-11-12 00:23:19,736 - 		TITLE: The default namespace should not be used
2021-11-12 00:23:19,737 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,737 - 		RESULT: passed
2021-11-12 00:23:19,783 - 	TESTID: TEST_POD_4
2021-11-12 00:23:19,784 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT1
2021-11-12 00:23:19,784 - 		PATHS: 
2021-11-12 00:23:19,784 - 			 /deployment/deployment-definition.yaml
2021-11-12 00:23:19,785 - 		TITLE:  Ensure pods outside of kube-system do not have access to node volume
2021-11-12 00:23:19,785 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,785 - 		RESULT: passed
2021-11-12 00:23:19,821 - 	TESTID: TEST_POD_4
2021-11-12 00:23:19,821 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT14
2021-11-12 00:23:19,821 - 		PATHS: 
2021-11-12 00:23:19,821 - 			 /test-multi-yaml/multiple-yamls/multiple-helm-response_multiple_yaml_2.yaml
2021-11-12 00:23:19,821 - 		TITLE:  Ensure pods outside of kube-system do not have access to node volume
2021-11-12 00:23:19,821 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,821 - 		RESULT: passed
2021-11-12 00:23:19,858 - 	TESTID: TEST_POD_5
2021-11-12 00:23:19,858 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT1
2021-11-12 00:23:19,858 - 		PATHS: 
2021-11-12 00:23:19,858 - 			 /deployment/deployment-definition.yaml
2021-11-12 00:23:19,859 - 		TITLE: Apply Security Context to Your Pods and Containers
2021-11-12 00:23:19,859 - 		DESCRIPTION: Apply Security Context to Your Pods and Containers. A security context defines the operating system security settings (uid, gid, capabilities, SELinux role, etc..) applied to a container. When designing your containers and pods, make sure that you configure the security context for your pods, containers, and volumes. A security context is a property defined in the deployment yaml. It controls the security parameters that will be assigned to the pod/container/volume.
2021-11-12 00:23:19,859 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,859 - 		ERROR: PR-K8S-0084-DCL: Apply Security Context to Your Pods and Containers
2021-11-12 00:23:19,859 - 		REMEDIATION: Follow the Kubernetes documentation and apply security contexts to your pods. For a suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker Containers. Please refer : https://kubernetes.io/docs/concepts/policy/security-context/
2021-11-12 00:23:19,859 - 		RESULT: failed
2021-11-12 00:23:19,893 - 	TESTID: TEST_POD_5
2021-11-12 00:23:19,893 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT14
2021-11-12 00:23:19,894 - 		PATHS: 
2021-11-12 00:23:19,894 - 			 /test-multi-yaml/multiple-yamls/multiple-helm-response_multiple_yaml_2.yaml
2021-11-12 00:23:19,894 - 		TITLE: Apply Security Context to Your Pods and Containers
2021-11-12 00:23:19,894 - 		DESCRIPTION: Apply Security Context to Your Pods and Containers. A security context defines the operating system security settings (uid, gid, capabilities, SELinux role, etc..) applied to a container. When designing your containers and pods, make sure that you configure the security context for your pods, containers, and volumes. A security context is a property defined in the deployment yaml. It controls the security parameters that will be assigned to the pod/container/volume.
2021-11-12 00:23:19,894 - 		RULE: file(pod.rego)
2021-11-12 00:23:19,895 - 		ERROR: PR-K8S-0084-DCL: Apply Security Context to Your Pods and Containers
2021-11-12 00:23:19,895 - 		REMEDIATION: Follow the Kubernetes documentation and apply security contexts to your pods. For a suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker Containers. Please refer : https://kubernetes.io/docs/concepts/policy/security-context/
2021-11-12 00:23:19,895 - 		RESULT: failed
2021-11-12 00:23:19,936 - 	TESTID: TEST_POD_SECURITY_POLICY_1
2021-11-12 00:23:19,936 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:19,937 - 		PATHS: 
2021-11-12 00:23:19,937 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:19,937 - 		TITLE: Minimize the admission of privileged containers (PSP)
2021-11-12 00:23:19,937 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:19,938 - 		RESULT: passed
2021-11-12 00:23:19,968 - 	TESTID: TEST_POD_SECURITY_POLICY_2
2021-11-12 00:23:19,969 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:19,969 - 		PATHS: 
2021-11-12 00:23:19,970 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:19,970 - 		TITLE: Minimize the admission of root containers (PSP)
2021-11-12 00:23:19,970 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:19,970 - 		RESULT: passed
2021-11-12 00:23:20,000 - 	TESTID: TEST_POD_SECURITY_POLICY_3
2021-11-12 00:23:20,000 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:20,001 - 		PATHS: 
2021-11-12 00:23:20,001 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:20,001 - 		TITLE: Minimize the admission of containers with the NET_RAW capability (PSP)
2021-11-12 00:23:20,001 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:20,001 - 		RESULT: passed
2021-11-12 00:23:20,030 - 	TESTID: TEST_POD_SECURITY_POLICY_4
2021-11-12 00:23:20,031 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:20,031 - 		PATHS: 
2021-11-12 00:23:20,031 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:20,031 - 		TITLE: Minimize the admission of containers wishing to share the host IPC namespace (PSP)
2021-11-12 00:23:20,031 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:20,032 - 		RESULT: passed
2021-11-12 00:23:20,061 - 	TESTID: TEST_POD_SECURITY_POLICY_5
2021-11-12 00:23:20,062 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:20,062 - 		PATHS: 
2021-11-12 00:23:20,062 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:20,062 - 		TITLE: Minimize the admission of containers wishing to share the host network namespace (PSP)
2021-11-12 00:23:20,062 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:20,062 - 		RESULT: passed
2021-11-12 00:23:20,096 - 	TESTID: TEST_POD_SECURITY_POLICY_6
2021-11-12 00:23:20,096 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:20,096 - 		PATHS: 
2021-11-12 00:23:20,097 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:20,097 - 		TITLE: Minimize the admission of containers wishing to share the host process ID namespace (PSP)
2021-11-12 00:23:20,097 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:20,097 - 		RESULT: passed
2021-11-12 00:23:20,125 - 	TESTID: TEST_POD_SECURITY_POLICY_7
2021-11-12 00:23:20,125 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT6
2021-11-12 00:23:20,125 - 		PATHS: 
2021-11-12 00:23:20,126 - 			 /pods/pod-security-policy.yaml
2021-11-12 00:23:20,126 - 		TITLE: Minimize the admission of containers with allowPrivilegeEscalation (PSP)
2021-11-12 00:23:20,126 - 		RULE: file(podSecurityPolicy.rego)
2021-11-12 00:23:20,126 - 		RESULT: passed
2021-11-12 00:23:20,149 - 	TESTID: TEST_SERVICE_ACCOUNT
2021-11-12 00:23:20,150 - 		SNAPSHOTID: K8S_TEMPLATE_SNAPSHOT12
2021-11-12 00:23:20,151 - 		PATHS: 
2021-11-12 00:23:20,151 - 			 /test-multi-yaml/multiple-yamls/multiple-helm-response_multiple_yaml_0.yaml
2021-11-12 00:23:20,151 - 		TITLE:  Ensure that Service Account Tokens are only mounted where necessary (RBAC)
2021-11-12 00:23:20,151 - 		RULE: file(serviceAccount.rego)
2021-11-12 00:23:20,151 - 		RESULT: passed
2021-11-12 00:23:20,157 - VALIDATION COMPLETE:
2021-11-12 00:23:20,161 -  Run Stats: {
  "start": "2021-11-12 00:23:15",
  "end": "2021-11-12 00:23:20",
  "remote": false,
  "errors": [],
  "host": "ee8f15e10fc5",
  "timestamp": "2021-11-12 00:23:15",
  "jsonsource": false,
  "database": 0,
  "container": "scenario-kubernetes-remote",
  "INCLUDESNAPSHOTS": false,
  "SNAPHSHOTIDS": [],
  "INCLUDETESTS": false,
  "TESTIDS": [],
  "ONLYSNAPSHOTS": false,
  "ONLYSNAPSHOTIDS": [],
  "singletest": false,
  "run_type": "COMPLIANCE",
  "log": null,
  "duration": "4 seconds"
}
```