### PR TITLE
update App Gateways

### DIFF
--- a/azure/cloud/applicationgateways.rego
+++ b/azure/cloud/applicationgateways.rego
@@ -18,7 +18,6 @@ azure_issue["gw_tls"] {
     resource := input.resources[_]
     lower(resource.type) == "microsoft.network/applicationgateways"
     lower(resource.properties.sslPolicy.minProtocolVersion) != "tlsv1_2"
-    lower(resource.properties.sslPolicy.minProtocolVersion) != "tlsv1_3"
 }
 
 gw_tls {
@@ -37,9 +36,7 @@ gw_tls = false {
 
 gw_tls_err = "Azure Application Gateway currently allowing TLSv1.1 or lower" {
     azure_issue["gw_tls"]
-}
-
-gw_tls_miss_err = "App gateway attribute sslPolicy.minProtocolVersion is missing from the resource" {
+} else = "App gateway attribute sslPolicy.minProtocolVersion is missing from the resource" {
     azure_attribute_absence["gw_tls"]
 }
 
@@ -90,9 +87,7 @@ gw_waf = false {
 
 gw_waf_err = "Azure Application Gateway currently does not have the Web application firewall (WAF) enabled" {
     azure_issue["gw_waf"]
-}
-
-gw_waf_miss_err = "Azure Application Gateway attribute webApplicationFirewallConfiguration.enabled is missing from the resource" {
+} else = "Azure Application Gateway attribute webApplicationFirewallConfiguration.enabled is missing from the resource" {
     azure_attribute_absence["gw_waf"]
 }
 

--- a/azure/iac/applicationgateways.rego
+++ b/azure/iac/applicationgateways.rego
@@ -29,14 +29,12 @@ azure_issue["gw_tls"] {
     resource := input.resources[_]
     lower(resource.type) == "microsoft.network/applicationgateways"
     lower(resource.properties.sslPolicy.minProtocolVersion) != "tlsv1_2"
-    lower(resource.properties.sslPolicy.minProtocolVersion) != "tlsv1_3"
 }
 
 source_path[{"gw_tls":metadata}] {
     resource := input.resources[i]
     lower(resource.type) == "microsoft.network/applicationgateways"
     lower(resource.properties.sslPolicy.minProtocolVersion) != "tlsv1_2"
-    lower(resource.properties.sslPolicy.minProtocolVersion) != "tlsv1_3"
     metadata:= {
         "resource_path": [["resources",i,"properties","sslPolicy","minProtocolVersion"]]
     }
@@ -58,9 +56,7 @@ gw_tls = false {
 
 gw_tls_err = "Azure Application Gateway currently allowing TLSv1.1 or lower" {
     azure_issue["gw_tls"]
-}
-
-gw_tls_miss_err = "App gateway attribute sslPolicy.minProtocolVersion is missing from the resource" {
+} else = "App gateway attribute sslPolicy.minProtocolVersion is missing from the resource" {
     azure_attribute_absence["gw_tls"]
 }
 
@@ -128,9 +124,7 @@ gw_waf = false {
 
 gw_waf_err = "Azure Application Gateway currently does not have the Web application firewall (WAF) enabled" {
     azure_issue["gw_waf"]
-}
-
-gw_waf_miss_err = "Azure Application Gateway attribute webApplicationFirewallConfiguration.enabled is missing from the resource" {
+} else = "Azure Application Gateway attribute webApplicationFirewallConfiguration.enabled is missing from the resource" {
     azure_attribute_absence["gw_waf"]
 }
 

--- a/azure/iac/master-compliance-test.json
+++ b/azure/iac/master-compliance-test.json
@@ -317,7 +317,7 @@
                             "id": "PR-AZR-ARM-AGW-001",
                             "eval": "data.rule.gw_tls",
                             "message": "data.rule.gw_tls_err",
-                            "remediationDescription": "Make sure you are following the ARM template guidelines for Application Gateway by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways' target='_blank'>here</a>. Ssl protocols to be disabled on application gateway. - TLSv1_0, TLSv1_1",
+                            "remediationDescription": "For resource type 'microsoft.network/applicationgateways' make sure 'properties.sslPolicy.minProtocolVersion' exists and the value is set to 'tlsv1_2' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#' target='_blank'>here</a> for details.",
                             "remediationFunction": "PR_AZR_ARM_AGW_001.py"
                         }
                     ],
@@ -356,7 +356,7 @@
                             "id": "PR-AZR-ARM-AGW-002",
                             "eval": "data.rule.gw_waf",
                             "message": "data.rule.gw_waf_err",
-                            "remediationDescription": "Make sure you are following the ARM template guidelines for Application Gateway by visiting <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways' target='_blank'>here</a>. webApplicationFirewallConfiguration should be enabled",
+                            "remediationDescription": "For resource type 'Microsoft.network/applicationgateways' make sure 'webApplicationFirewallConfiguration.enabled' exists and the value is set to 'true' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#' target='_blank'>here</a> for details.",
                             "remediationFunction": "PR_AZR_ARM_AGW_002.py"
                         }
                     ],
@@ -394,7 +394,7 @@
                             "id": "PR-AZR-ARM-AGW-003",
                             "eval": "data.rule.protocol",
                             "message": "data.rule.protocol_err",
-                            "remediationDescription": "",
+                            "remediationDescription": "For resource type 'Microsoft.network/applicationgateways' make sure 'properties.protocol' under 'properties.httpListeners' exists and the value is set to 'Https' to fix the issue.<br>Please visit <a href='https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json#' target='_blank'>here</a> for details.",
                             "remediationFunction": "PR_AZR_ARM_AGW_003.py"
                         }
                     ],

--- a/azure/terraform/applicationgateways.rego
+++ b/azure/terraform/applicationgateways.rego
@@ -36,7 +36,6 @@ azure_issue["gw_tls"] {
     lower(resource.type) == "azurerm_application_gateway"
     ssl_policy := resource.properties.ssl_policy[_]
     lower(ssl_policy.min_protocol_version) != "tlsv1_2"
-    lower(ssl_policy.min_protocol_version) != "tlsv1_3"
 }
 
 gw_tls {


### PR DESCRIPTION
According to these below references the value of ```minProtocolVersion``` on IaC and ```min_protocol_version```  on terraform can not set to ```TLSv1_3```:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway
https://docs.microsoft.com/en-us/azure/templates/microsoft.network/applicationgateways?tabs=json

also updated remediation description for ```PR-AZR-ARM-AGW-001``` ,```PR-AZR-ARM-AGW-002``` and ```PR-AZR-ARM-AGW-003```